### PR TITLE
Fix issue #9

### DIFF
--- a/r2-testapp-swift/AppDelegate.swift
+++ b/r2-testapp-swift/AppDelegate.swift
@@ -63,7 +63,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         window = UIWindow(frame: UIScreen.main.bounds)
         window?.backgroundColor = #colorLiteral(red: 1, green: 1, blue: 1, alpha: 1)
 
-        let publications = items.flatMap() { $0.value.0.publication }
+        let publications = items.flatMap() { $0.value.0.publication }.sorted { (pA, pB) -> Bool in
+            pA.metadata.title < pB.metadata.title
+        }
+        
         guard let libraryVC = LibraryViewController(publications) else {
             print("Error instanciating the LibraryVC.")
             return false


### PR DESCRIPTION
fixes issue #9 

This is a typical use case on iOS when doing some Async update on UICollectionView or UITableView.

I simply added some code checking whether does it still have the same book you are expecting at the index path you are going to update. There is no such callback in Kingfisher, so I just use the ImageDownloader and ImageCache manually. 

Change the default sorting order of testing books.