### PR TITLE
fix issue #29

### DIFF
--- a/r2-testapp-swift/AppDelegate.swift
+++ b/r2-testapp-swift/AppDelegate.swift
@@ -26,6 +26,10 @@ public enum PublicationType: String {
     case epub = "epub"
     case cbz = "cbz"
     case unknown = "unknown"
+
+    init(rawString: String?) {
+        self = PublicationType(rawValue: rawString ?? "") ?? .unknown
+    }
 }
 
 @UIApplicationMain

--- a/r2-testapp-swift/LibraryViewController.swift
+++ b/r2-testapp-swift/LibraryViewController.swift
@@ -312,9 +312,9 @@ class PublicationIndicator: UIView  {
         self.backgroundColor = UIColor(white: 0.3, alpha: 0.7)
         self.addSubview(result)
         
-        let hConstraint = NSLayoutConstraint(item: result, attribute: .centerX, relatedBy: .equal, toItem: self, attribute: .centerX, multiplier: 1.0, constant: 0.0)
-        let vConstraint = NSLayoutConstraint(item: result, attribute: .centerY, relatedBy: .equal, toItem: self, attribute: .centerY, multiplier: 1.0, constant: 0.0)
-        self.addConstraints([hConstraint, vConstraint])
+        let horizontalConstraint = NSLayoutConstraint(item: result, attribute: .centerX, relatedBy: .equal, toItem: self, attribute: .centerX, multiplier: 1.0, constant: 0.0)
+        let verticalConstraint = NSLayoutConstraint(item: result, attribute: .centerY, relatedBy: .equal, toItem: self, attribute: .centerY, multiplier: 1.0, constant: 0.0)
+        self.addConstraints([horizontalConstraint, verticalConstraint])
         
         return result
     } ()

--- a/r2-testapp-swift/LibraryViewController.swift
+++ b/r2-testapp-swift/LibraryViewController.swift
@@ -30,11 +30,7 @@ class LibraryViewController: UICollectionViewController {
     weak var delegate: LibraryViewControllerDelegate?
     weak var lastFlippedCell: PublicationCell?
     
-    lazy var loadingIndicator: PublicationIndicator = {
-        
-        let indicator = PublicationIndicator()
-        return indicator
-    } ()
+    lazy var loadingIndicator = PublicationIndicator()
 
     init?(_ publications: [Publication]) {
         self.publications = publications


### PR DESCRIPTION
fixes #29

This PR fixed issue #29 by disable user interaction while loading book asynchronizly, then re-enable it after the loading task. It also added a little visual indicator for loading. 

I will replace the loading indicator later with other PR. It should be treated as enhancement. Consider the loading process of LCP book, it also need some visual indicator.