### PR TITLE
Fix issue #15

### DIFF
--- a/r2-testapp-swift/AppDelegate.swift
+++ b/r2-testapp-swift/AppDelegate.swift
@@ -14,6 +14,7 @@ import CryptoSwift
 
 #if LCP
 import ReadiumLCP
+import R2LCPClient
 #endif
 
 struct Location {
@@ -85,8 +86,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     /// Called when the user open a file outside of the application and open it
     /// with the application.
-    func application(_ application: UIApplication, open url: URL,
-                     sourceApplication: String?, annotation: Any) -> Bool
+        
+    func application(_ app: UIApplication,
+                     open url: URL,
+                     options: [UIApplicationOpenURLOptionsKey : Any] = [:]) -> Bool
+        
     {
         guard url.isFileURL else {
             showInfoAlert(title: "Error", message: "The document isn't valid.")
@@ -477,11 +481,11 @@ extension AppDelegate: LibraryViewControllerDelegate {
         }
 
         // Fonction used in the async code below.
-        func promptPassphrase() -> Promise<String> {
+        func promptPassphrase(reason:String? = nil) -> Promise<String> {
             let hint = session.getHint()
 
             return firstly {
-                self.promptPassphrase(hint)
+                self.promptPassphrase(hint, reason: reason)
                 }.then { clearPassphrase -> Promise<String?> in
                     let passphraseHash = clearPassphrase.sha256()
 
@@ -492,6 +496,46 @@ extension AppDelegate: LibraryViewControllerDelegate {
                     }
                     try session.storePassphrase(validPassphraseHash)
                     return Promise(value: validPassphraseHash)
+            }
+        }
+        
+        //https://stackoverflow.com/questions/30523285/how-do-i-create-an-inline-recursive-closure-in-swift
+        // Quick fix for error catch, because it's using Promise and there are so many func(closure) with captured values, there will be alot trouble to make them as seprated funcions. That's a dirty fix, shoud be refactored later all together.
+        var catchError:((Error) -> Void)!
+        catchError = { error in
+            
+            guard let lcpClientError = error as? LCPClientError else {
+                self.showInfoAlert(title: "Error", message: error.localizedDescription)
+                completion(nil)
+                return
+            }
+            
+            let askPassphrase = { (reason: String) -> Void in
+                firstly {
+                    return promptPassphrase(reason: reason)
+                    }.then { passphraseHash -> Promise<LcpLicense> in
+                        return validatePassphrase(passphraseHash: passphraseHash)
+                    }.then { lcpLicense -> Void in
+                        
+                        var drm = drm
+                        drm.license = lcpLicense
+                        drm.profile = session.getProfile()
+                        /// Update container.drm to drm and parse the remaining elements.
+                        try? parsingCallback(drm)
+                        // Tell the caller than we done.
+                        completion(drm)
+                    }.catch(execute: catchError)
+            }
+            
+            switch lcpClientError {
+            case .userKeyCheckInvalid:
+                askPassphrase("LCP Passphrase updated")
+            case .noValidPassphraseFound:
+                askPassphrase("Wrong LCP Passphrase")
+            default:
+                self.showInfoAlert(title: "Error", message: error.localizedDescription)
+                completion(nil)
+                return
             }
         }
 
@@ -528,17 +572,16 @@ extension AppDelegate: LibraryViewControllerDelegate {
                 try? parsingCallback(drm)
                 // Tell the caller than we done.
                 completion(drm)
-            }.catch { error in
-                self.showInfoAlert(title: "Error", message: error.localizedDescription)
-                completion(nil)
-        }
+            }.catch(execute: catchError)
     }
     
     // Ask a passphrase to the user and verify it
-    fileprivate func promptPassphrase(_ hint: String) -> Promise<String>
+    fileprivate func promptPassphrase(_ hint: String, reason: String? = nil) -> Promise<String>
     {
         return Promise<String> { fullfil, reject in
-            let alert = UIAlertController(title: "LCP Passphrase",
+            
+            let title = reason ?? "LCP Passphrase"
+            let alert = UIAlertController(title: title,
                                           message: hint, preferredStyle: .alert)
             let dismissButton = UIAlertAction(title: "Cancel", style: .cancel)
             let confirmButton = UIAlertAction(title: "Submit", style: .default) { (_) in


### PR DESCRIPTION
Fixed #15. Depends on this [PR](https://github.com/readium/r2-lcp-swift/pull/6) for LCP.

The bug is derived from several reasons.

One of them happens when updating `license.lcpl`, `ZIPFoundation` will keep both the old file and new file. So the app is always using old license, no wonder it will fail to validate.

Another reason is bigger but easier to see. There is no error treatment for the LCP process. Because it's using PromiseKit, all the `errors` and `throws` will fly to the final `catch`, but there is only alert waiting for them. 

This PR simply added special treatment for passphrase related error. The way how PromiseKit was used for LCP process could be improved. And there are some redundancy code, we can improve later.





