### PR TITLE
Fix catch policy for the error catch promise

### DIFF
--- a/r2-testapp-swift/AppDelegate.swift
+++ b/r2-testapp-swift/AppDelegate.swift
@@ -525,7 +525,7 @@ extension AppDelegate: LibraryViewControllerDelegate {
                         try? parsingCallback(drm)
                         // Tell the caller than we done.
                         completion(drm, nil)
-                    }.catch(execute: catchError)
+                    }.catch(policy: CatchPolicy.allErrors, execute:catchError)
             }
             
             switch lcpClientError {


### PR DESCRIPTION
This PR fixed catch policy for the error catch, so the error pipeline will connected.

The `NSError.cancelledError()` from `PromiseKit` will pass to error handle code successfully.