### PR TITLE
Adjust item number per row in library

### DIFF
--- a/r2-testapp-swift/LibraryViewController.swift
+++ b/r2-testapp-swift/LibraryViewController.swift
@@ -100,6 +100,8 @@ class LibraryViewController: UICollectionViewController {
         .phone : iPhoneLayoutNumberPerRow
     ]
     
+    private var previousScreenOrientation: GeneralScreenOrientation?
+    
     override func viewWillLayoutSubviews() {
         super.viewWillLayoutSubviews()
         
@@ -109,8 +111,19 @@ class LibraryViewController: UICollectionViewController {
         } ()
         
         let orientation = { () -> GeneralScreenOrientation in
-            return UIDevice.current.orientation.isPortrait ? GeneralScreenOrientation.portrait:GeneralScreenOrientation.landscape
+            let deviceOrientation = UIDevice.current.orientation
+            
+            switch deviceOrientation {
+            case .unknown, .portrait, .portraitUpsideDown:
+                    return GeneralScreenOrientation.portrait
+            case .landscapeLeft, .landscapeRight:
+                    return GeneralScreenOrientation.landscape
+            case .faceUp, .faceDown:
+                return previousScreenOrientation ?? .portrait
+            }
         } ()
+        
+        previousScreenOrientation = orientation
         
         guard let deviceLayoutNumberPerRow = layoutNumberPerRow[idiom] else {return}
         guard let numberPerRow = deviceLayoutNumberPerRow[orientation] else {return}
@@ -124,7 +137,6 @@ class LibraryViewController: UICollectionViewController {
         
         flowLayout.minimumLineSpacing = minimumSpacing * 2
         flowLayout.minimumInteritemSpacing = minimumSpacing
-        
         flowLayout.itemSize = CGSize(width: width, height: height)
     }
 }

--- a/r2-testapp-swift/LibraryViewController.swift
+++ b/r2-testapp-swift/LibraryViewController.swift
@@ -13,9 +13,6 @@ import R2Streamer
 import R2Navigator
 import Kingfisher
 
-let bookPerRow = 3
-let insets = 5 // In px.
-
 /// To modify depending of the profile of the liblcp.a used
 let supportedProfiles = ["http://readium.org/lcp/basic-profile",
                         "http://readium.org/lcp/profile-1.0"]
@@ -43,6 +40,9 @@ class LibraryViewController: UICollectionViewController {
     }
 
     override func loadView() {
+        // What is the reason creating another flowLayout?
+        // What is the reason creating another collectionView?
+        // Why not use the build in properites from UICollectionViewController?
         let flowLayout = UICollectionViewFlowLayout()
         let collectionView = UICollectionView(frame: UIScreen.main.bounds,
                                               collectionViewLayout: flowLayout)
@@ -53,6 +53,7 @@ class LibraryViewController: UICollectionViewController {
         collectionView.register(PublicationCell.self,
                                 forCellWithReuseIdentifier: "publicationCell")
         collectionView.delegate = self
+        
         self.collectionView = collectionView
         view = collectionView
     }
@@ -84,6 +85,47 @@ class LibraryViewController: UICollectionViewController {
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
         super.viewWillTransition(to: size, with: coordinator)
         collectionView?.collectionViewLayout.invalidateLayout()
+    }
+    
+    enum GeneralScreenOrientation: String {
+        case landscape
+        case portrait
+    }
+    
+    static let iPadLayoutNumberPerRow:[GeneralScreenOrientation: Int] = [.portrait: 4, .landscape: 5]
+    static let iPhoneLayoutNumberPerRow:[GeneralScreenOrientation: Int] = [.portrait: 3, .landscape: 4]
+    
+    lazy var layoutNumberPerRow:[UIUserInterfaceIdiom:[GeneralScreenOrientation: Int]] = [
+        .pad : iPadLayoutNumberPerRow,
+        .phone : iPhoneLayoutNumberPerRow
+    ]
+    
+    override func viewWillLayoutSubviews() {
+        super.viewWillLayoutSubviews()
+        
+        let idiom = { () -> UIUserInterfaceIdiom in
+            let tempIdion = UIDevice.current.userInterfaceIdiom
+            return (tempIdion != .pad) ? .phone:.pad // ignnore carplay and others
+        } ()
+        
+        let orientation = { () -> GeneralScreenOrientation in
+            return UIDevice.current.orientation.isPortrait ? GeneralScreenOrientation.portrait:GeneralScreenOrientation.landscape
+        } ()
+        
+        guard let deviceLayoutNumberPerRow = layoutNumberPerRow[idiom] else {return}
+        guard let numberPerRow = deviceLayoutNumberPerRow[orientation] else {return}
+        
+        guard let flowLayout = self.collectionView?.collectionViewLayout as? UICollectionViewFlowLayout else {return}
+        let contentWith = collectionView?.collectionViewLayout.collectionViewContentSize.width ?? 0
+        
+        let minimumSpacing = CGFloat(5)
+        let width = (contentWith - CGFloat(numberPerRow-1) * minimumSpacing) / CGFloat(numberPerRow)
+        let height = width * 1.5 // Height/width ratio == 1.5
+        
+        flowLayout.minimumLineSpacing = minimumSpacing * 2
+        flowLayout.minimumInteritemSpacing = minimumSpacing
+        
+        flowLayout.itemSize = CGSize(width: width, height: height)
     }
 }
 
@@ -162,8 +204,10 @@ extension LibraryViewController: UICollectionViewDelegateFlowLayout {
             
         } else {
             
-            let width = (Int(UIScreen.main.bounds.width) / bookPerRow) - (bookPerRow * 2 * insets)
-            let height = Int(Double(width) * 1.5) // Height/width ratio == 1.5
+            let flowLayout = collectionView.collectionViewLayout as? UICollectionViewFlowLayout
+            
+            let width = flowLayout?.itemSize.width ?? 0
+            let height = flowLayout?.itemSize.height ?? 0
             let titleTextView = UITextView(frame: CGRect(x: 0, y: 0, width: width, height: height))
             
             titleTextView.layer.borderWidth = 5.0
@@ -177,20 +221,7 @@ extension LibraryViewController: UICollectionViewDelegateFlowLayout {
         
         return pCell
     }
-
-    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, insetForSectionAt section: Int) -> UIEdgeInsets
-    {
-        let inset = CGFloat(insets)
-
-        return UIEdgeInsets(top: inset, left: inset, bottom: inset, right: inset)
-    }
     
-    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
-        let width = (Int(UIScreen.main.bounds.width) / bookPerRow) - (bookPerRow * 2 * insets)
-        let height = Int(Double(width) * 1.5) // Height/width ratio == 1.5
-        return CGSize(width: width, height: height)
-    }
-
     override func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         
         let publication = publications[indexPath.row]


### PR DESCRIPTION
fixes #43  
Adjust item number per row in library, using the properties of flowlayout instead of delegate. 