### PR TITLE
Fix #86  UIPopoverPresentationController

### DIFF
--- a/r2-testapp-swift/AdvancedSettingsViewController.swift
+++ b/r2-testapp-swift/AdvancedSettingsViewController.swift
@@ -41,8 +41,6 @@ class AdvancedSettingsViewController: UIViewController {
     weak var delegate: AdvancedSettingsDelegate?
     weak var userSettings: UserSettings?
     
-    weak var popoverController: UIPopoverPresentationController?
-    
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(true)
         delegate?.updateWordSpacingLabel()
@@ -53,7 +51,7 @@ class AdvancedSettingsViewController: UIViewController {
         super.viewWillAppear(true)
         navigationController?.setNavigationBarHidden(false, animated: animated)
         
-        if let ppc = popoverController  {
+        if let ppc = popoverPresentationController  {
             let preferredSize = self.preferredContentSize
             self.navigationController?.preferredContentSize = CGSize.zero
             self.navigationController?.preferredContentSize = preferredSize

--- a/r2-testapp-swift/EpubViewController.swift
+++ b/r2-testapp-swift/EpubViewController.swift
@@ -153,8 +153,6 @@ extension EpubViewController {
 
         popoverPresentationController.delegate = self
         popoverPresentationController.barButtonItem = popoverUserconfigurationAnchor
-        
-        userSettingNavigationController.popoverController = popoverPresentationController
 
         present(userSettingNavigationController, animated: true, completion: nil)
     }

--- a/r2-testapp-swift/UserSettingsNavigationController.swift
+++ b/r2-testapp-swift/UserSettingsNavigationController.swift
@@ -24,8 +24,6 @@ internal class UserSettingsNavigationController: UINavigationController {
     //
     weak var usdelegate: UserSettingsNavigationControllerDelegate!
     var userSettings: UserSettings!
-    
-    weak var popoverController: UIPopoverPresentationController?
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -33,7 +31,6 @@ internal class UserSettingsNavigationController: UINavigationController {
         userSettings = usdelegate.getUserSettings()
 
         userSettingsTableViewController = viewControllers[0] as! UserSettingsTableViewController
-        userSettingsTableViewController.popoverController = self.popoverController
         
         fontSelectionViewController =
             storyboard.instantiateViewController(withIdentifier: "FontSelectionViewController") as! FontSelectionViewController

--- a/r2-testapp-swift/UserSettingsTableViewController.swift
+++ b/r2-testapp-swift/UserSettingsTableViewController.swift
@@ -29,8 +29,6 @@ class UserSettingsTableViewController: UITableViewController {
     @IBOutlet weak var scrollSwitch: UISwitch!
     weak var delegate: UserSettingsDelegate?
     weak var userSettings: UserSettings?
-    
-    weak var popoverController: UIPopoverPresentationController?
 
     let maxFontSize: Float = 250.0
     let minFontSize: Float = 75.0
@@ -61,7 +59,7 @@ class UserSettingsTableViewController: UITableViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         navigationController?.setNavigationBarHidden(true, animated: animated)
-        if let ppc = popoverController  {
+        if let ppc = popoverPresentationController  {
             let preferredSize = self.preferredContentSize
             self.navigationController?.preferredContentSize = CGSize.zero
             self.navigationController?.preferredContentSize = preferredSize
@@ -130,8 +128,6 @@ class UserSettingsTableViewController: UITableViewController {
 
         backItem.title = ""
         navigationItem.backBarButtonItem = backItem
-        
-        asvc.popoverController = self.popoverController
         navigationController?.pushViewController(asvc, animated: true)
 //        present(asvc, animated: true, completion: nil)
     }


### PR DESCRIPTION
It's using weak reference for popoverPresentationController, the reference will disappeared after dismiss the menu. This PR replaced weak reference with system API. So it will always get the correct reference.

Close #86 