### PR TITLE
Minor UI changes for OPDS screens

### DIFF
--- a/r2-testapp-swift/OPDS.storyboard
+++ b/r2-testapp-swift/OPDS.storyboard
@@ -352,29 +352,29 @@
             <objects>
                 <viewController storyboardIdentifier="opdsPublicationInfoViewController" id="lur-JP-MVV" customClass="OPDSPublicationInfoViewController" customModule="r2_testapp_swift" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="HIB-E8-IjS">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="618"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="7pH-jP-xI4">
-                                <rect key="frame" x="0.0" y="20" width="375" height="647"/>
+                                <rect key="frame" x="0.0" y="20" width="375" height="598"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="mmy-bu-8by" userLabel="book">
-                                        <rect key="frame" x="0.0" y="0.0" width="375" height="323.5"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="375" height="299"/>
                                         <subviews>
                                             <imageView userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="Sci-QS-dhx">
-                                                <rect key="frame" x="0.0" y="0.0" width="375" height="333"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="375" height="308.5"/>
                                             </imageView>
                                             <visualEffectView opaque="NO" contentMode="scaleAspectFill" translatesAutoresizingMaskIntoConstraints="NO" id="rTD-gk-NtE">
-                                                <rect key="frame" x="0.0" y="0.0" width="375" height="333"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="375" height="308.5"/>
                                                 <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="ZZn-5b-Y8M">
-                                                    <rect key="frame" x="0.0" y="0.0" width="375" height="333"/>
+                                                    <rect key="frame" x="0.0" y="0.0" width="375" height="308.5"/>
                                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                     <subviews>
                                                         <visualEffectView opaque="NO" contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="nG7-uA-lHC">
-                                                            <rect key="frame" x="0.0" y="0.0" width="375" height="332"/>
+                                                            <rect key="frame" x="0.0" y="0.0" width="375" height="307"/>
                                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                             <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" ambiguous="YES" insetsLayoutMarginsFromSafeArea="NO" id="OtA-OX-d8A">
-                                                                <rect key="frame" x="0.0" y="0.0" width="375" height="332"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="375" height="307"/>
                                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                             </view>
                                                             <vibrancyEffect>
@@ -386,7 +386,7 @@
                                                 <blurEffect style="light"/>
                                             </visualEffectView>
                                             <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="57T-El-2sR">
-                                                <rect key="frame" x="8" y="8" width="359" height="307.5"/>
+                                                <rect key="frame" x="8" y="8" width="359" height="283"/>
                                             </imageView>
                                         </subviews>
                                         <constraints>
@@ -405,7 +405,7 @@
                                         </constraints>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="WYE-Hq-hFh" userLabel="info">
-                                        <rect key="frame" x="0.0" y="323.5" width="375" height="323.5"/>
+                                        <rect key="frame" x="0.0" y="299" width="375" height="299"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cgc-Pq-nWR">
                                                 <rect key="frame" x="8" y="30" width="359" height="18"/>
@@ -422,19 +422,12 @@
                                                 <nil key="textColor"/>
                                                 <color key="highlightedColor" red="0.38068733809999999" green="0.38068733809999999" blue="0.38068733809999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                             </label>
-                                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" editable="NO" textAlignment="justified" selectable="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ZVE-iD-fWW">
-                                                <rect key="frame" x="8" y="86" width="359" height="128"/>
-                                                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                <string key="text">Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.</string>
-                                                <fontDescription key="fontDescription" type="system" weight="thin" pointSize="14"/>
-                                                <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
-                                            </textView>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ZIq-yW-8qr">
-                                                <rect key="frame" x="133" y="230" width="110" height="40"/>
+                                                <rect key="frame" x="133" y="251" width="110" height="40"/>
                                                 <color key="backgroundColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <constraints>
-                                                    <constraint firstAttribute="height" constant="40" id="IwM-4m-uNb"/>
-                                                    <constraint firstAttribute="width" constant="110" id="vDQ-i2-SH8"/>
+                                                    <constraint firstAttribute="width" constant="110" id="EX9-Ev-0bu"/>
+                                                    <constraint firstAttribute="height" constant="40" id="mBR-Z5-xqt"/>
                                                 </constraints>
                                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="15"/>
                                                 <state key="normal" title="Download">
@@ -445,30 +438,34 @@
                                                 </connections>
                                             </button>
                                             <activityIndicatorView hidden="YES" opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" hidesWhenStopped="YES" style="white" translatesAutoresizingMaskIntoConstraints="NO" id="bFT-zY-8al">
-                                                <rect key="frame" x="251" y="231.5" width="37" height="37"/>
+                                                <rect key="frame" x="251" y="253" width="37" height="37"/>
                                                 <constraints>
-                                                    <constraint firstAttribute="height" constant="37" id="4ts-zA-yYw"/>
-                                                    <constraint firstAttribute="width" constant="37" id="lNg-UZ-BwC"/>
+                                                    <constraint firstAttribute="width" constant="37" id="E0N-UB-k8X"/>
+                                                    <constraint firstAttribute="height" constant="37" id="uu2-4h-hYE"/>
                                                 </constraints>
                                                 <color key="color" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                             </activityIndicatorView>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" text="Label" textAlignment="justified" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Dhv-oz-JD9">
+                                                <rect key="frame" x="8" y="86" width="359" height="16"/>
+                                                <fontDescription key="fontDescription" type="system" weight="thin" pointSize="13"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
                                         </subviews>
                                         <constraints>
                                             <constraint firstItem="cgc-Pq-nWR" firstAttribute="leading" secondItem="WYE-Hq-hFh" secondAttribute="leading" constant="8" id="1SI-bu-p3N"/>
+                                            <constraint firstItem="Dhv-oz-JD9" firstAttribute="leading" secondItem="WYE-Hq-hFh" secondAttribute="leading" constant="8" id="4jj-EA-rK8"/>
                                             <constraint firstAttribute="trailing" secondItem="cgc-Pq-nWR" secondAttribute="trailing" constant="8" id="6fg-5h-F5Z"/>
                                             <constraint firstItem="cgc-Pq-nWR" firstAttribute="top" secondItem="WYE-Hq-hFh" secondAttribute="top" constant="30" id="757-nC-NE1"/>
+                                            <constraint firstAttribute="trailing" secondItem="Dhv-oz-JD9" secondAttribute="trailing" constant="8" id="9xE-WY-Zx6"/>
+                                            <constraint firstItem="ZIq-yW-8qr" firstAttribute="centerX" secondItem="WYE-Hq-hFh" secondAttribute="centerX" id="BB4-Mg-Gzd"/>
                                             <constraint firstItem="jb4-he-yej" firstAttribute="top" secondItem="cgc-Pq-nWR" secondAttribute="bottom" constant="8" id="C8N-gT-HM8"/>
-                                            <constraint firstItem="ZIq-yW-8qr" firstAttribute="centerX" secondItem="WYE-Hq-hFh" secondAttribute="centerX" id="Dwc-Ok-CFW"/>
-                                            <constraint firstItem="bFT-zY-8al" firstAttribute="leading" secondItem="ZIq-yW-8qr" secondAttribute="trailing" constant="8" id="Ics-I3-Kn5"/>
-                                            <constraint firstItem="ZVE-iD-fWW" firstAttribute="leading" secondItem="WYE-Hq-hFh" secondAttribute="leading" constant="8" id="QHW-25-jtL"/>
-                                            <constraint firstAttribute="trailing" secondItem="ZVE-iD-fWW" secondAttribute="trailing" constant="8" id="fSK-d6-G5p"/>
-                                            <constraint firstItem="ZIq-yW-8qr" firstAttribute="top" secondItem="ZVE-iD-fWW" secondAttribute="bottom" constant="16" id="hyt-iS-pfE"/>
-                                            <constraint firstItem="ZIq-yW-8qr" firstAttribute="centerY" secondItem="WYE-Hq-hFh" secondAttribute="centerY" constant="88.25" id="jwB-PO-Q3L"/>
+                                            <constraint firstItem="bFT-zY-8al" firstAttribute="leading" secondItem="ZIq-yW-8qr" secondAttribute="trailing" constant="8" id="R7K-zb-krW"/>
+                                            <constraint firstItem="Dhv-oz-JD9" firstAttribute="top" secondItem="jb4-he-yej" secondAttribute="bottom" constant="8" id="Sry-DD-fD8"/>
+                                            <constraint firstItem="bFT-zY-8al" firstAttribute="centerY" secondItem="ZIq-yW-8qr" secondAttribute="centerY" id="ggb-Ft-Gxk"/>
                                             <constraint firstItem="jb4-he-yej" firstAttribute="leading" secondItem="WYE-Hq-hFh" secondAttribute="leading" constant="8" id="quF-sa-mWo"/>
                                             <constraint firstItem="jb4-he-yej" firstAttribute="top" secondItem="cgc-Pq-nWR" secondAttribute="bottom" constant="8" id="tiB-Kb-cME"/>
                                             <constraint firstAttribute="trailing" secondItem="jb4-he-yej" secondAttribute="trailing" constant="8" id="tmc-QE-fYJ"/>
-                                            <constraint firstItem="bFT-zY-8al" firstAttribute="centerY" secondItem="ZIq-yW-8qr" secondAttribute="centerY" id="tuq-rj-SwI"/>
-                                            <constraint firstItem="ZVE-iD-fWW" firstAttribute="top" secondItem="jb4-he-yej" secondAttribute="bottom" constant="8" id="w17-qp-vy6"/>
                                         </constraints>
                                     </view>
                                 </subviews>
@@ -502,16 +499,19 @@
                         </subviews>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
+                            <constraint firstItem="ZIq-yW-8qr" firstAttribute="top" secondItem="2mG-I6-dZy" secondAttribute="bottom" constant="-48" id="GXL-TX-LaF"/>
                             <constraint firstItem="7pH-jP-xI4" firstAttribute="bottom" secondItem="2mG-I6-dZy" secondAttribute="bottom" id="SiG-8i-POz"/>
                             <constraint firstItem="7pH-jP-xI4" firstAttribute="leading" secondItem="2mG-I6-dZy" secondAttribute="leading" id="Z7I-An-4XX"/>
                             <constraint firstItem="7pH-jP-xI4" firstAttribute="top" secondItem="2mG-I6-dZy" secondAttribute="top" id="apv-zj-Gqx"/>
+                            <constraint firstItem="2mG-I6-dZy" firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="Dhv-oz-JD9" secondAttribute="bottom" constant="56" id="aqp-eR-eOm"/>
                             <constraint firstItem="7pH-jP-xI4" firstAttribute="trailing" secondItem="2mG-I6-dZy" secondAttribute="trailing" id="dq5-dh-a1H"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="2mG-I6-dZy"/>
                     </view>
+                    <simulatedTabBarMetrics key="simulatedBottomBarMetrics" translucent="NO"/>
                     <connections>
                         <outlet property="authorLabel" destination="jb4-he-yej" id="8dg-qh-VFz"/>
-                        <outlet property="descriptionTextView" destination="ZVE-iD-fWW" id="mN7-aT-3aq"/>
+                        <outlet property="descriptionLabel" destination="Dhv-oz-JD9" id="Apa-AF-Hix"/>
                         <outlet property="downloadActivityIndicator" destination="bFT-zY-8al" id="hkG-Zw-FTM"/>
                         <outlet property="downloadButton" destination="ZIq-yW-8qr" id="HhM-V6-vuw"/>
                         <outlet property="fxImageView" destination="Sci-QS-dhx" id="Gau-Xd-fg1"/>

--- a/r2-testapp-swift/OPDSPublicationInfoViewController.swift
+++ b/r2-testapp-swift/OPDSPublicationInfoViewController.swift
@@ -18,7 +18,7 @@ class OPDSPublicationInfoViewController : UIViewController {
     @IBOutlet weak var fxImageView: UIImageView!
     @IBOutlet weak var titleLabel: UILabel!
     @IBOutlet weak var authorLabel: UILabel!
-    @IBOutlet weak var descriptionTextView: UITextView!
+    @IBOutlet weak var descriptionLabel: UILabel!
     @IBOutlet weak var downloadButton: UIButton!
     @IBOutlet weak var downloadActivityIndicator: UIActivityIndicatorView!
 
@@ -59,7 +59,8 @@ class OPDSPublicationInfoViewController : UIViewController {
         
         titleLabel.text = publication?.metadata.title
         authorLabel.text = publication?.metadata.authors.map({$0.name ?? ""}).joined(separator: ", ")
-        descriptionTextView.text = publication?.metadata.description
+        descriptionLabel.text = publication?.metadata.description
+        descriptionLabel.sizeToFit()
         
         downloadActivityIndicator.stopAnimating()
         

--- a/r2-testapp-swift/OPDSRootTableViewController.swift
+++ b/r2-testapp-swift/OPDSRootTableViewController.swift
@@ -38,7 +38,7 @@ class OPDSRootTableViewController: UITableViewController {
     }
     
     static let iPadLayoutHeightForRow:[GeneralScreenOrientation: CGFloat] = [.portrait: 330, .landscape: 340]
-    static let iPhoneLayoutHeightForRow:[GeneralScreenOrientation: CGFloat] = [.portrait: 220, .landscape: 280]
+    static let iPhoneLayoutHeightForRow:[GeneralScreenOrientation: CGFloat] = [.portrait: 230, .landscape: 280]
     
     lazy var layoutHeightForRow:[UIUserInterfaceIdiom:[GeneralScreenOrientation: CGFloat]] = [
         .pad : OPDSRootTableViewController.iPadLayoutHeightForRow,


### PR DESCRIPTION
- Use a label in place of a text view for the publication description (prevent the auto scrolling to bottom)
- A label inside a group cell could be cropped on an iPhone 8 Plus