### PR TITLE
Use the OPDS Parser intermediate structure

### DIFF
--- a/r2-testapp-swift/OPDSRootTableViewController.swift
+++ b/r2-testapp-swift/OPDSRootTableViewController.swift
@@ -424,12 +424,26 @@ class OPDSRootTableViewController: UITableViewController {
     
     func buildNavigationCell(tableView: UITableView, indexPath: IndexPath) -> OPDSNavigationTableViewCell {
         let castedCell = tableView.dequeueReusableCell(withIdentifier: "opdsNavigationCell", for: indexPath) as! OPDSNavigationTableViewCell
-        castedCell.title.text = feed?.navigation[indexPath.row].title
-        if let count = feed?.navigation[indexPath.row].properties.numberOfItems {
-            castedCell.count.text = "\(count)"
+        
+        var currentNavigation: [Link]?
+        
+        if let navigation = feed?.navigation, navigation.count > 0 {
+            currentNavigation = navigation
         } else {
-            castedCell.count.text = ""
+            if let navigation = feed?.groups[indexPath.section].navigation, navigation.count > 0 {
+                currentNavigation = navigation
+            }
         }
+
+        if let currentNavigation = currentNavigation {
+            castedCell.title.text = currentNavigation[indexPath.row].title
+            if let count = currentNavigation[indexPath.row].properties.numberOfItems {
+                castedCell.count.text = "\(count)"
+            } else {
+                castedCell.count.text = ""
+            }
+        }
+        
         return castedCell
     }
     


### PR DESCRIPTION
Fix readium/readium-opds-swift/issues/16 - Add helper method to handle OPDS 1.x/2.0 parsing (*intermediate structure*)

OPDS Parser will now returns a intermediate structure with: 
- `feed` XOR `publication`
- `version`
- `url`
- `response` (URLResponse: payload + headers)