### PR TITLE
Use downloading percentage

### DIFF
--- a/r2-testapp-swift/AppDelegate.swift
+++ b/r2-testapp-swift/AppDelegate.swift
@@ -365,7 +365,7 @@ extension AppDelegate {
         return firstly {
             /// 3.1/ Fetch the status document.
             /// 3.2/ Validate the status document.
-            return lcpLicense.fetchStatusDocument(freshNew: true)
+            return lcpLicense.fetchStatusDocument(initialDownloadAttempt: true)
             }.then { _ -> Promise<Void> in
                 /// 3.3/ Check that the status is "ready" or "active".
                 try lcpLicense.checkStatus()

--- a/r2-testapp-swift/AppDelegate.swift
+++ b/r2-testapp-swift/AppDelegate.swift
@@ -114,9 +114,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     fileprivate func reload() {
         // Update library publications.
-        //libraryViewController?.publications = publicationServer.publications
+        libraryViewController?.publications = publicationServer.publications
         // Redraw cells
-        //libraryViewController?.collectionView.reloadData()
+        libraryViewController?.collectionView.reloadData()
         libraryViewController?.collectionView.backgroundView = nil
     }
 
@@ -174,10 +174,9 @@ extension AppDelegate {
                     showInfoAlert(title: "Error", message: "The publication isn't valid.")
                     return false
                 } else {
-                    //showInfoAlert(title: "Success", message: "Publication added to library.")
-                    reload()
+                    showInfoAlert(title: "Success", message: "Publication added to library.")
+                    //reload()
                 }
-                
             }
         }
         

--- a/r2-testapp-swift/AppDelegate.swift
+++ b/r2-testapp-swift/AppDelegate.swift
@@ -114,9 +114,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     fileprivate func reload() {
         // Update library publications.
-        libraryViewController?.publications = publicationServer.publications
+        //libraryViewController?.publications = publicationServer.publications
         // Redraw cells
-        libraryViewController?.collectionView.reloadData()
+        //libraryViewController?.collectionView.reloadData()
         libraryViewController?.collectionView.backgroundView = nil
     }
 
@@ -174,7 +174,7 @@ extension AppDelegate {
                     showInfoAlert(title: "Error", message: "The publication isn't valid.")
                     return false
                 } else {
-                    showInfoAlert(title: "Success", message: "Publication added to library.")
+                    //showInfoAlert(title: "Success", message: "Publication added to library.")
                     reload()
                 }
                 

--- a/r2-testapp-swift/AppDelegate.swift
+++ b/r2-testapp-swift/AppDelegate.swift
@@ -116,7 +116,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Update library publications.
         libraryViewController?.publications = publicationServer.publications
         // Redraw cells
-        libraryViewController?.collectionView.reloadData()
+        guard let collectionView = libraryViewController?.collectionView else {return}
+        let range = collectionView.indexPathsForVisibleItems
+        libraryViewController?.collectionView.reloadItems(at: range)
         libraryViewController?.collectionView.backgroundView = nil
     }
 

--- a/r2-testapp-swift/AppDelegate.swift
+++ b/r2-testapp-swift/AppDelegate.swift
@@ -100,16 +100,15 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         alert.addAction(dismissButton)
         alert.title = title
         alert.message = message
-
-        // Present alert.
-//        if alert.isBeingPresented  {
-//            alert.dismiss(animated: false, completion: {
-//                self.window?.rootViewController?.present(self.alert, animated: false)
-//            })
-//        } else {
-            window?.rootViewController?.dismiss(animated: false, completion: nil)
-            window?.rootViewController?.present(alert, animated: true)
-//        }
+        
+        guard let rootViewController = self.window?.rootViewController else {return}
+        if let _  = rootViewController.presentedViewController {
+            rootViewController.dismiss(animated: true) {
+                rootViewController.present(alert, animated: true)
+            }
+        } else {
+            rootViewController.present(alert, animated: true)
+        }
     }
 
     fileprivate func reload() {
@@ -366,7 +365,7 @@ extension AppDelegate {
         return firstly {
             /// 3.1/ Fetch the status document.
             /// 3.2/ Validate the status document.
-            return lcpLicense.fetchStatusDocument()
+            return lcpLicense.fetchStatusDocument(freshNew: true)
             }.then { _ -> Promise<Void> in
                 /// 3.3/ Check that the status is "ready" or "active".
                 try lcpLicense.checkStatus()

--- a/r2-testapp-swift/LibraryViewController.swift
+++ b/r2-testapp-swift/LibraryViewController.swift
@@ -444,7 +444,10 @@ extension LibraryViewController: DownloadDisplayDelegate {
         downloadSet.remove(task)
         downloadTaskToRatio.removeValue(forKey: task)
         
-        publications = appDelegate?.publicationServer.publications
+        guard let newList = appDelegate?.publicationServer.publications else {return}
+        if newList.count == publications.count {return}
+        
+        publications = newList
         
         let theIndexPath = IndexPath(item: offset, section: 0)
         let newIndexPath = IndexPath(item: downloadSet.count, section: 0)
@@ -461,7 +464,7 @@ extension LibraryViewController: DownloadDisplayDelegate {
         })
     }
     
-    func didFailWithError(task:URLSessionDownloadTask, error: Error) {
+    func didFailWithError(task:URLSessionDownloadTask, error: Error?) {
         
         let offset = downloadSet.index(of: task)
         downloadSet.remove(task)

--- a/r2-testapp-swift/OPDSPublicationInfoViewController.swift
+++ b/r2-testapp-swift/OPDSPublicationInfoViewController.swift
@@ -81,11 +81,9 @@ class OPDSPublicationInfoViewController : UIViewController {
             UIApplication.shared.isNetworkActivityIndicatorVisible = true
             downloadButton.isEnabled = false
             
-            let sessionConfiguration = URLSessionConfiguration.default
-            let session = URLSession(configuration: sessionConfiguration)
             let request = URLRequest(url:url)
             
-            let task = session.downloadTask(with: request) { (localURL, response, error) in
+            DownloadSession.shared.launch(request: request, completionHandler: { (localURL, response, error) in
                 if let localURL = localURL, error == nil {
                     // Download succeed
                     // downloadTask renames the file download, thus to be parsed correctly according to
@@ -114,10 +112,7 @@ class OPDSPublicationInfoViewController : UIViewController {
                     UIApplication.shared.isNetworkActivityIndicatorVisible = false
                     self.downloadButton.isEnabled = true
                 }
-            }
-            
-            task.resume()
-            
+            })
         }
         
     }

--- a/r2-testapp-swift/OPDSPublicationInfoViewController.swift
+++ b/r2-testapp-swift/OPDSPublicationInfoViewController.swift
@@ -83,7 +83,14 @@ class OPDSPublicationInfoViewController : UIViewController {
             
             let request = URLRequest(url:url)
             
-            DownloadSession.shared.launch(request: request, completionHandler: { (localURL, response, error) in
+            DownloadSession.shared.launch(request: request, completionHandler: { (localURL, response, error) -> Bool in
+                
+                DispatchQueue.main.async {
+                    self.downloadActivityIndicator.stopAnimating()
+                    UIApplication.shared.isNetworkActivityIndicatorVisible = false
+                    self.downloadButton.isEnabled = true
+                }
+                
                 if let localURL = localURL, error == nil {
                     // Download succeed
                     // downloadTask renames the file download, thus to be parsed correctly according to
@@ -95,23 +102,19 @@ class OPDSPublicationInfoViewController : UIViewController {
                     } catch {
                         print("\(error)")
                     }
-                    DispatchQueue.main.async {
-                        // We use the app delegate method that handle the adding of a publication to the
-                        // document library
-                        if let appDelegate = UIApplication.shared.delegate as? AppDelegate {
-                            let _ = appDelegate.addPublicationToLibrary(url: fixedURL)
-                        }
+                    
+                    guard let appDelegate = UIApplication.shared.delegate as? AppDelegate else {
+                        return false
                     }
+                    
+                    return appDelegate.addPublicationToLibrary(url: fixedURL)
+                    
                 } else {
                     // Download failed
                     print("Error while downloading a publication.")
                 }
                 
-                DispatchQueue.main.async {
-                    self.downloadActivityIndicator.stopAnimating()
-                    UIApplication.shared.isNetworkActivityIndicatorVisible = false
-                    self.downloadButton.isEnabled = true
-                }
+                return false
             })
         }
         

--- a/r2-testapp-swift/PublicationCell.swift
+++ b/r2-testapp-swift/PublicationCell.swift
@@ -20,6 +20,37 @@ class PublicationCell: UICollectionViewCell {
     var imageView: UIImageView
     var menuView: CellMenuView
     var cardView: (frontView: UIView, backView: UIView)?
+    
+    var progress:Float = 0.0 {
+        didSet {
+            progressView.progress = progress
+            let hidden = (progress == 0 || progress == 1)
+            if hidden !=  progressView.isHidden {
+                progressView.isHidden = hidden
+                if hidden {
+                    self.backgroundColor = UIColor.clear
+                } else {
+                    self.backgroundColor = UIColor.lightGray
+                }
+            } //
+        }
+    }
+    
+    private lazy var progressView: UIProgressView = {
+        
+        let pView = UIProgressView(progressViewStyle: .bar)
+        pView.translatesAutoresizingMaskIntoConstraints = false
+        self.addSubview(pView)    
+        
+        let leftConstraint = NSLayoutConstraint(item: pView, attribute: .left, relatedBy: .equal, toItem: self, attribute: .left, multiplier: 1.0, constant: 0.0)
+        let rightConstraint = NSLayoutConstraint(item: pView, attribute: .right, relatedBy: .equal, toItem: self, attribute: .right, multiplier: 1.0, constant: 0.0)
+        let verticalConstraint = NSLayoutConstraint(item: pView, attribute: .bottom, relatedBy: .equal, toItem: self, attribute: .bottom, multiplier: 1.0, constant: 0.0)
+        
+        self.addConstraints([leftConstraint, rightConstraint, verticalConstraint])
+
+        return pView
+    } ()
+    
     //
     weak var delegate: PublicationCellDelegate?
 


### PR DESCRIPTION
This PR will adds a placeholder when downloading LCP or OPDS book, and display a progress bar based on the feedback from server. 

For OPDS, it's using smooth partial reload when download finished or failed. For LCP, it's full reload due to the execution order or promise chain and download callback. 

fix #40 