### PR TITLE
Fix async delete operaation

### DIFF
--- a/r2-testapp-swift/LibraryViewController.swift
+++ b/r2-testapp-swift/LibraryViewController.swift
@@ -390,14 +390,32 @@ func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath:
 extension LibraryViewController: PublicationCellDelegate {
   
   func removePublicationFromLibrary(forCellAt indexPath: IndexPath) {
+
+    let offset = downloadSet.count
+    let index = indexPath.item-offset
+    
+    if index >= self.publications.count {return}
+
+    let publication = self.publications[index]
+    
     let removePublicationAlert = UIAlertController(title: "Are you sure?",
                                                    message: "This will remove the Publication from your library.",
                                                    preferredStyle: UIAlertControllerStyle.alert)
     let removeAction = UIAlertAction(title: "Remove", style: .destructive, handler: { alert in
       // Remove the publication from publicationServer and Documents folder.
-      self.delegate?.remove(self.publications[indexPath.row])
-      // Remove item from UI colletionView.
-      self.collectionView.deleteItems(at: [indexPath])
+        // TODO.
+        
+        let newOffset = self.downloadSet.count
+        guard let newIndex = self.publications.index(where: { (element) -> Bool in
+            publication.metadata.identifier == element.metadata.identifier
+        }) else {return}
+        let newIndexPath = IndexPath(item: newOffset+newIndex, section: 0)
+        
+        self.delegate?.remove(publication)
+         // Remove item from UI colletionView.
+        self.collectionView.performBatchUpdates({
+            self.collectionView.deleteItems(at: [newIndexPath])
+        }, completion: nil)
     })
     let cancelAction = UIAlertAction(title: "Cancel", style: .cancel, handler: { alert in
       return


### PR DESCRIPTION
For any async operation on UICollectionView. IndexPath is not reliable. 
This solution acquires new IndexPath before really deleting the book. 