### PR TITLE
Minor UI updates to make CBZ viewer looks like EPUB viewer

### DIFF
--- a/r2-testapp-swift/CbzViewController.swift
+++ b/r2-testapp-swift/CbzViewController.swift
@@ -19,6 +19,7 @@ class CbzViewController: CbzNavigatorViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         navigationController?.setNavigationBarHidden(true, animated: false)
+        navigationController?.navigationBar.tintColor = UIColor.black
     }
 
     override func viewDidAppear(_ animated: Bool) {
@@ -33,7 +34,7 @@ class CbzViewController: CbzNavigatorViewController {
         view.addGestureRecognizer(swipeRight)
         view.addGestureRecognizer(swipeLeft)
         // SpineItemView button.
-        let spineItemButton = UIBarButtonItem(title: "📖", style: .plain, target: self,
+        let spineItemButton = UIBarButtonItem(image: #imageLiteral(resourceName: "menuIcon"), style: .plain, target: self,
                                               action: #selector(presentSpineItemsTVC))
         /// Add spineItemViewController button to navBar.
         navigationItem.setRightBarButtonItems([spineItemButton], animated: true)

--- a/r2-testapp-swift/LibraryViewController.swift
+++ b/r2-testapp-swift/LibraryViewController.swift
@@ -345,6 +345,7 @@ extension LibraryViewController: UICollectionViewDelegateFlowLayout, UICollectio
         switch publicationType {
         case .cbz:
             let cbzViewer = CbzViewController(for: publication, initialIndex: 0)
+            cbzViewer.hidesBottomBarWhenPushed = true
             success?(cbzViewer)
         case .epub:
             guard let publicationIdentifier = publication.metadata.identifier else {


### PR DESCRIPTION
Fix #135 

So CBZ is already working fine (opening, zoom, navigation...). But this PR updates the UI to use the same look'n'feel of the EPUB viewer (nav bar tint color, nav bar hidden by default, spine item icon).