### PR TITLE
Add title to download placeholder and remove LCP info in database when should

### DIFF
--- a/r2-testapp-swift/AppDelegate.swift
+++ b/r2-testapp-swift/AppDelegate.swift
@@ -684,6 +684,11 @@ extension AppDelegate: LibraryViewControllerDelegate {
             if let lcpLicense = try? LcpLicense(withLicenseDocumentIn: url) {
                 try? lcpLicense.removeDataBaseItem()
             }
+            // In case, the epub download succeed but the process inserting lcp into epub failed
+            if filename.starts(with: "lcp.") {
+                let possibleLCPID = url.deletingPathExtension().lastPathComponent
+                try? LcpLicense.removeDataBaseItem(licenseID: possibleLCPID)
+            }
             #endif
             
             removeFromDocumentsDirectory(fileName: filename)

--- a/r2-testapp-swift/AppDelegate.swift
+++ b/r2-testapp-swift/AppDelegate.swift
@@ -131,7 +131,7 @@ extension AppDelegate {
                                                                relativePath: "",
                                                                type: .epub)) {
                         
-                        self.showInfoAlert(title: "Success", message: "LCP Publication added to library.")
+                        //self.showInfoAlert(title: "Success", message: "LCP Publication added to library.")
                         self.reload(downloadTask: downloadTask)
                     } else {
                         self.showInfoAlert(title: "Error", message: "The LCP Publication couldn't be loaded.")
@@ -171,7 +171,6 @@ extension AppDelegate {
                     showInfoAlert(title: "Error", message: "The publication isn't valid.")
                     return false
                 } else {
-                    showInfoAlert(title: "Success", message: "Publication added to library.")
                     if needUIUpdate {
                         reload(downloadTask: nil)
                     }

--- a/r2-testapp-swift/AppDelegate.swift
+++ b/r2-testapp-swift/AppDelegate.swift
@@ -354,7 +354,7 @@ extension AppDelegate {
     ///   - path: The path of the License Document (LCPL).
     ///   - completion: The handler to be called on completion.
     internal func publication(at url: URL) throws -> Promise<(URL, URLSessionDownloadTask?)> {
-        showInfoAlert(title: "Downloading", message: "The publication is being fetched in the background and will be available soon.")
+        showInfoAlert(title: "Importing", message: "R2Reader is trying to import the LCP publication and will be available soon.")
         /// Here we use a lcpLicense, and that's avoidable.
         /// Normally the streamer scan for DRM
         let lcpLicense = try LcpLicense.init(withLicenseDocumentAt: url)
@@ -679,6 +679,12 @@ extension AppDelegate: LibraryViewControllerDelegate {
         
         if let url = URL(string: path) {
             let filename = url.lastPathComponent
+            
+            #if LCP
+            if let lcpLicense = try? LcpLicense(withLicenseDocumentIn: url) {
+                try? lcpLicense.removeDataBaseItem()
+            }
+            #endif
             
             removeFromDocumentsDirectory(fileName: filename)
         }

--- a/r2-testapp-swift/AppDelegate.swift
+++ b/r2-testapp-swift/AppDelegate.swift
@@ -131,7 +131,6 @@ extension AppDelegate {
                                                                relativePath: "",
                                                                type: .epub)) {
                         
-                        //self.showInfoAlert(title: "Success", message: "LCP Publication added to library.")
                         self.reload(downloadTask: downloadTask)
                     } else {
                         self.showInfoAlert(title: "Error", message: "The LCP Publication couldn't be loaded.")

--- a/r2-testapp-swift/OPDSPublicationInfoViewController.swift
+++ b/r2-testapp-swift/OPDSPublicationInfoViewController.swift
@@ -86,8 +86,9 @@ class OPDSPublicationInfoViewController : UIViewController {
             downloadButton.isEnabled = false
             
             let request = URLRequest(url:url)
+            let description = publication?.metadata.title
             
-            DownloadSession.shared.launch(request: request, completionHandler: { (localURL, response, error, downloadTask) -> Bool in
+            DownloadSession.shared.launch(request: request, description: description, completionHandler: { (localURL, response, error, downloadTask) -> Bool in
                 
                 DispatchQueue.main.async {
                     self.downloadActivityIndicator.stopAnimating()


### PR DESCRIPTION
It's more friendly to show the title on download placeholder. 
So the user could see which book is been downloading.

Remove the database item when removing the LCP book.
So the duplicate check could work.