### PR TITLE
Fix the EPUB title issue for iPhone X, fix the contentInset for iOS 9/10

### DIFF
--- a/r2-testapp-swift/AppMain.storyboard
+++ b/r2-testapp-swift/AppMain.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14109" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="vEH-Wa-DdV">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14113" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="vEH-Wa-DdV">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
@@ -84,12 +84,12 @@
         <!--Library-->
         <scene sceneID="JIb-eP-eRV">
             <objects>
-                <viewController id="4L6-5j-ce4" customClass="LibraryViewController" customModule="r2_testapp_swift" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController automaticallyAdjustsScrollViewInsets="NO" id="4L6-5j-ce4" customClass="LibraryViewController" customModule="r2_testapp_swift" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="UPL-MW-x8R">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="618"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="5l4-XZ-QZP">
+                            <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="5l4-XZ-QZP">
                                 <rect key="frame" x="0.0" y="64" width="375" height="554"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="10" minimumInteritemSpacing="10" id="elb-4x-lyb">

--- a/r2-testapp-swift/EpubViewController.swift
+++ b/r2-testapp-swift/EpubViewController.swift
@@ -73,6 +73,17 @@ class EpubViewController: UIViewController {
         
         view.addSubview(stackView)
         
+        if #available(iOS 11, *) {
+            let safeArea = view.safeAreaLayoutGuide
+            stackView.translatesAutoresizingMaskIntoConstraints = false
+            NSLayoutConstraint.activate([
+                stackView.topAnchor.constraint(equalTo: safeArea.topAnchor),
+                self.stackView.bottomAnchor.constraint(equalTo: safeArea.bottomAnchor),
+                self.stackView.leadingAnchor.constraint(equalTo: safeArea.leadingAnchor),
+                self.stackView.trailingAnchor.constraint(equalTo: safeArea.trailingAnchor),
+            ])
+        }
+        
         /// Set initial UI appearance.
         if let appearance = navigator.publication.userProperties.getProperty(reference: ReadiumCSSReference.appearance.rawValue) {
             setUIColor(for: appearance)

--- a/r2-testapp-swift/LibraryViewController.swift
+++ b/r2-testapp-swift/LibraryViewController.swift
@@ -50,6 +50,11 @@ class LibraryViewController: UIViewController {
     
     @IBOutlet weak var collectionView: UICollectionView! {
         didSet {
+            // The contentInset of collectionVIew might be changed by iOS 9/10.
+            // This property has been set as false on storyboard.
+            // In case it's changed by mistake somewhere, set it again here.
+            self.automaticallyAdjustsScrollViewInsets = false
+            
             collectionView.backgroundColor = #colorLiteral(red: 1.0, green: 1.0, blue: 1.0, alpha: 1.0)
             collectionView.contentInset = UIEdgeInsets(top: 15, left: 20,
                                                        bottom: 20, right: 20)


### PR DESCRIPTION
In `EpubViewController`, this PR added constraints to the `stackView`respecting to `SafeArea`.
As the result, EPUB title is now visible on iPhone X simulator.

It also solved the strange contentInset on iOS 9/10.