### PR TITLE
 Use user-settings-presets on the settings menu

### DIFF
--- a/r2-testapp-swift/AdvancedSettingsViewController.swift
+++ b/r2-testapp-swift/AdvancedSettingsViewController.swift
@@ -49,7 +49,8 @@ class AdvancedSettingsViewController: UIViewController {
     @IBOutlet weak var pageMarginsLabel: UILabel!
     @IBOutlet weak var lineHeightLabel: UILabel!
     weak var delegate: AdvancedSettingsDelegate?
-    weak var userSettings: UserSettings? 
+    weak var userSettings: UserSettings?
+    weak var publication: Publication?
     
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(true)
@@ -98,7 +99,7 @@ class AdvancedSettingsViewController: UIViewController {
             ReadiumCSSName.letterSpacing: letterSpacingLabel.superview?.superview
         ]
         
-        userSettings?.userSettingsUIPreset?.forEach({ (key, value) in
+        publication?.userSettingsUIPreset?.forEach({ (key, value) in
             if let theUIComponent = settingsUIPreset[key] {
                 if !value {
                     let disabledColor = UIColor(white: 0.6, alpha: 0.4)

--- a/r2-testapp-swift/BarView.swift
+++ b/r2-testapp-swift/BarView.swift
@@ -45,7 +45,9 @@ open class BarView: UIView {
             return
         }
         removeConstraints(constraints)
-        heightAnchor.constraint(equalToConstant: height).isActive = true
+        let heightConstraint = heightAnchor.constraint(equalToConstant: height)
+        heightConstraint.priority = UILayoutPriority(rawValue: 999)
+        heightConstraint.isActive = true
     }
 
     public func setLabel(title: String?) {

--- a/r2-testapp-swift/EpubViewController.swift
+++ b/r2-testapp-swift/EpubViewController.swift
@@ -178,6 +178,21 @@ class EpubViewController: UIViewController {
         /// Add spineItemViewController button to navBar.
         navigationItem.setRightBarButtonItems(barButtons,
                                               animated: true)
+        
+        
+       
+        self.userSettingNavigationController.userSettingsTableViewController.publication = navigator.publication
+        
+        self.navigator.publication.userSettingsUIPresetUpdated = { (thisUserSettingsUIPreset) in
+            
+            guard let presetScrollValue:Bool = thisUserSettingsUIPreset?[.scroll] else {return}
+            
+            if let scroll = self.userSettingNavigationController.userSettings.userProperties.getProperty(reference: ReadiumCSSReference.scroll.rawValue) as? Switchable {
+                if scroll.on != presetScrollValue {
+                    self.userSettingNavigationController.scrollModeDidChange()
+                }
+            }
+        }
     }
     
     override func viewDidAppear(_ animated: Bool) {
@@ -227,9 +242,7 @@ extension EpubViewController {
         popoverPresentationController.delegate = self
         popoverPresentationController.barButtonItem = popoverUserconfigurationAnchor
         
-        let userSettingsUIPreset = self.navigator.publication.userSettingsUIPreset
-        userSettingNavigationController.userSettings.userSettingsUIPreset = userSettingsUIPreset
-        
+        userSettingNavigationController.publication = self.navigator.publication
         present(userSettingNavigationController, animated: true, completion: nil)
     }
     

--- a/r2-testapp-swift/EpubViewController.swift
+++ b/r2-testapp-swift/EpubViewController.swift
@@ -142,6 +142,9 @@ class EpubViewController: UIViewController {
         fixedTopBar.delegate = self
         fixedBottomBar.delegate = self
         navigator.delegate = self
+        
+        let userSettings = navigator.userSettings
+        userSettingNavigationController.userSettings = userSettings
     }
     
     override func viewDidLoad() {
@@ -223,6 +226,9 @@ extension EpubViewController {
         
         popoverPresentationController.delegate = self
         popoverPresentationController.barButtonItem = popoverUserconfigurationAnchor
+        
+        let userSettingsUIPreset = self.navigator.publication.userSettingsUIPreset
+        userSettingNavigationController.userSettings.userSettingsUIPreset = userSettingsUIPreset
         
         present(userSettingNavigationController, animated: true, completion: nil)
     }

--- a/r2-testapp-swift/UserSettings.storyboard
+++ b/r2-testapp-swift/UserSettings.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14109" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14113" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina5_9" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
@@ -82,7 +82,7 @@
                                                     </connections>
                                                 </button>
                                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="dau-vB-tiS">
-                                                    <rect key="frame" x="124.66666666666667" y="-0.66666666666666785" width="0.3333333333333286" height="45.666666666666671"/>
+                                                    <rect key="frame" x="124.5" y="-0.5" width="0.5" height="45.5"/>
                                                     <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="45" id="8d3-Ak-GC1"/>
@@ -619,6 +619,8 @@
                     <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
                     <size key="freeformSize" width="250" height="400"/>
                     <connections>
+                        <outlet property="alignSegment" destination="wd1-SD-2dm" id="Tt3-A0-Vqe"/>
+                        <outlet property="columnsSegment" destination="El2-dy-YXY" id="F6O-T3-snA"/>
                         <outlet property="defaultSwitch" destination="a7V-SY-NbP" id="LEK-Y0-Ejf"/>
                         <outlet property="letterSpacingLabel" destination="7D5-LE-bsa" id="zUV-MC-nic"/>
                         <outlet property="lineHeightLabel" destination="oHs-C3-4vp" id="Phs-dc-Ap8"/>

--- a/r2-testapp-swift/UserSettingsNavigationController.swift
+++ b/r2-testapp-swift/UserSettingsNavigationController.swift
@@ -22,20 +22,23 @@ protocol UserSettingsNavigationControllerDelegate: class {
 }
 
 internal class UserSettingsNavigationController: UINavigationController {
-    var userSettingsTableViewController: UserSettingsTableViewController!
+    var userSettingsTableViewController: UserSettingsTableViewController! {
+        get {
+            return viewControllers[0] as! UserSettingsTableViewController
+        }
+    }
     //
     var fontSelectionViewController: FontSelectionViewController!
     var advancedSettingsViewController: AdvancedSettingsViewController!
     //
     weak var usdelegate: UserSettingsNavigationControllerDelegate!
     var userSettings: UserSettings!
+    weak var publication: Publication?
 
     override func viewDidLoad() {
         super.viewDidLoad()
         let storyboard = UIStoryboard(name: "UserSettings", bundle: nil)
         userSettings = usdelegate.getUserSettings()
-
-        userSettingsTableViewController = viewControllers[0] as! UserSettingsTableViewController
         
         fontSelectionViewController =
             storyboard.instantiateViewController(withIdentifier: "FontSelectionViewController") as! FontSelectionViewController
@@ -91,7 +94,7 @@ extension UserSettingsNavigationController: UserSettingsDelegate {
 
     /// Vertical scroll
     
-    func scrollDidChange() {
+    func scrollModeDidChange() {
         if let scroll = userSettings.userProperties.getProperty(reference: ReadiumCSSReference.scroll.rawValue) as? Switchable {
             scroll.switchValue()
             usdelegate?.updateUserSettingsStyle()

--- a/r2-testapp-swift/UserSettingsNavigationController.swift
+++ b/r2-testapp-swift/UserSettingsNavigationController.swift
@@ -53,6 +53,7 @@ internal class UserSettingsNavigationController: UINavigationController {
         fontSelectionViewController.userSettings = userSettings
         advancedSettingsViewController.delegate = self
         advancedSettingsViewController.userSettings = userSettings
+        advancedSettingsViewController.publication = publication
     }
     
     /// Publisher's default

--- a/r2-testapp-swift/UserSettingsTableViewController.swift
+++ b/r2-testapp-swift/UserSettingsTableViewController.swift
@@ -18,7 +18,7 @@ import R2Shared
 protocol UserSettingsDelegate: class {
     func fontSizeDidChange(increase: Bool)
     func appearanceDidChange(to appearanceIndex: Int)
-    func scrollDidChange()
+    func scrollModeDidChange()
     func getFontSelectionViewController() -> FontSelectionViewController
     func getAdvancedSettingsViewController() -> AdvancedSettingsViewController
 }
@@ -34,6 +34,7 @@ class UserSettingsTableViewController: UITableViewController {
     @IBOutlet weak var scrollSwitch: UISwitch!
     weak var delegate: UserSettingsDelegate?
     weak var userSettings: UserSettings?
+    weak var publication: Publication? 
 
     private var brightnessObserver: NSObjectProtocol?
 
@@ -55,6 +56,18 @@ class UserSettingsTableViewController: UITableViewController {
             currentFontSize.max = 250.0
             currentFontSize.min = 75.0
             currentFontSize.step = 12.5
+        }
+        
+        checkScrollMode()
+    }
+    
+    func checkScrollMode() {
+        if let scrollMode = publication?.userSettingsUIPreset?[.scroll] {
+            scrollSwitch.isUserInteractionEnabled = false
+            scrollSwitch.backgroundColor = UIColor.gray
+            if scrollSwitch?.isOn != scrollMode {
+                scrollModeSwitched()
+            }
         }
     }
     
@@ -122,8 +135,8 @@ class UserSettingsTableViewController: UITableViewController {
         navigationController?.pushViewController(asvc, animated: true)
     }
 
-    @IBAction func scrollSwitched() {
-        delegate?.scrollDidChange()
+    @IBAction func scrollModeSwitched() {
+        delegate?.scrollModeDidChange()
     }
 }
 

--- a/r2-testapp-swift/UserSettingsTableViewController.swift
+++ b/r2-testapp-swift/UserSettingsTableViewController.swift
@@ -34,7 +34,7 @@ class UserSettingsTableViewController: UITableViewController {
     @IBOutlet weak var scrollSwitch: UISwitch!
     weak var delegate: UserSettingsDelegate?
     weak var userSettings: UserSettings?
-    weak var publication: Publication? 
+    weak var publication: Publication?
 
     private var brightnessObserver: NSObjectProtocol?
 
@@ -64,7 +64,9 @@ class UserSettingsTableViewController: UITableViewController {
     func checkScrollMode() {
         if let scrollMode = publication?.userSettingsUIPreset?[.scroll] {
             scrollSwitch.isUserInteractionEnabled = false
-            scrollSwitch.backgroundColor = UIColor.gray
+            scrollSwitch.thumbTintColor = UIColor.gray
+            scrollSwitch.tintColor = UIColor.lightGray
+            scrollSwitch.onTintColor = UIColor.lightGray
             if scrollSwitch?.isOn != scrollMode {
                 scrollModeSwitched()
             }


### PR DESCRIPTION
The `user settings preset` is a preset of settings which is compatible with the layout of book.
The un-compatible settings will be disabled by for different cases.

It's selected when Streamer is trying to parse the book. Then the value is parsed before presenting the settings menu. 


Fixed a layout warning when the UI component is hidden. 
`heightConstraint.priority = UILayoutPriority(rawValue: 999)`