### PR TITLE
Fix user settings

### DIFF
--- a/r2-testapp-swift/Reader/EPUB/User Settings/AdvancedSettingsViewController.swift
+++ b/r2-testapp-swift/Reader/EPUB/User Settings/AdvancedSettingsViewController.swift
@@ -190,13 +190,11 @@ class AdvancedSettingsViewController: UIViewController {
     @IBAction func pageMarginsPlusTapped() {
         delegate?.incrementPageMargins()
         delegate?.updatePageMarginsLabel()
-        switchOffPublisherSettingsIfNeeded()
     }
 
     @IBAction func pageMarginsMinusTapped() {
         delegate?.decrementPageMargins()
         delegate?.updatePageMarginsLabel()
-        switchOffPublisherSettingsIfNeeded()
     }
 
     public func updatePageMargins(value: String) {
@@ -225,6 +223,5 @@ class AdvancedSettingsViewController: UIViewController {
     
     @IBAction func columnCountValueChanged(_ sender: UISegmentedControl) {
         delegate?.columnCountDidChange(to: sender.selectedSegmentIndex)
-        switchOffPublisherSettingsIfNeeded()
     }
 }


### PR DESCRIPTION
Don't disable publisher's defaults when it's not needed (e.g. when changing page margins or column count).